### PR TITLE
Feature/meaningful send results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1", default-features = false, features = [
     "macros",
     "rt",
     "sync",
+    "time",
 ] }
 tracing = { version = "0.1", optional = true }
 url = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,7 @@ mod tests {
         assert_eq!(received_message, message);
         // We should send a ping in here
         sleep(Duration::from_millis(2200)).await;
+        // Ensure everything shuts down so we exercize the ping functionality fully
         socketeer.close_connection().await.unwrap();
     }
 
@@ -317,7 +318,7 @@ mod tests {
     #[tokio::test]
     async fn test_close_request() {
         let server_address = get_mock_address(echo_server).await;
-        let mut socketeer: Socketeer<EchoControlMessage, EchoControlMessage> =
+        let socketeer: Socketeer<EchoControlMessage, EchoControlMessage> =
             Socketeer::connect(&format!("ws://{server_address}",))
                 .await
                 .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,8 @@ async fn rx_loop(
 
 #[cfg(test)]
 mod tests {
+    use tokio::time::sleep;
+
     use super::*;
 
     #[tokio::test]
@@ -280,6 +282,9 @@ mod tests {
         socketeer.send(message.clone()).await.unwrap();
         let received_message = socketeer.next_message().await.unwrap();
         assert_eq!(received_message, message);
+        // We should send a ping in here
+        sleep(Duration::from_millis(3250)).await;
+        socketeer.close_connection().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,6 @@ mod tests {
         // TODO: Send needs to pass a one-shot and actually wait for the result
         let send_result = socketeer.send(close_request).await;
         assert!(send_result.is_err());
-        println!("{:?}", send_result);
         assert!(matches!(
             send_result.unwrap_err(),
             Error::WebsocketError(..)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,9 +130,9 @@ impl<RxMessage: for<'a> Deserialize<'a> + Debug, TxMessage: Serialize + Debug>
             })
             .await
             .map_err(|_| Error::WebSocketClosed)?;
-        let _ = rx.await.unwrap()?;
-        let _ = self.tx_handle.await.unwrap();
-        let _ = self.rx_handle.await.unwrap();
+        rx.await.unwrap()?;
+        self.tx_handle.await.unwrap();
+        self.rx_handle.await.unwrap();
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ async fn tx_loop(mut receiver: mpsc::Receiver<TxChannelPayload>, mut sink: Socke
 
         message
             .response_tx
-            .send(sink.send(message.message).await.map_err(|e| Error::from(e)))
+            .send(sink.send(message.message).await.map_err(Error::from))
             .unwrap();
     }
 }


### PR DESCRIPTION
Added result type `oneshot` to tx channel so that he send task can return the result of the transmission before returning a response to the sender.
Also updated close_connection to take ownership of self and properly shut everything down.

Closes: #3