### PR TITLE
Feature/single loop

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,11 +13,13 @@ pub enum Error {
     #[error("Tungstenite error: {0}")]
     WebsocketError(#[from] tokio_tungstenite::tungstenite::Error),
     #[error("Socket Closed")]
-    WebSocketClosed,
+    WebsocketClosed,
     #[error("Channel Full")]
     ChannelFull,
     #[error("Unexpected Message type: {0}")]
     UnexpectedMessage(Message),
     #[error("Serialization Error: {0}")]
     SerializationError(#[from] serde_json::Error),
+    #[error("Socketeer dropped without closing")]
+    SocketeerDropped,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl<RxMessage: for<'a> Deserialize<'a> + Debug, TxMessage: Serialize + Debug>
     #[cfg_attr(feature = "tracing", instrument)]
     pub async fn next_message(&mut self) -> Result<RxMessage, Error> {
         let Some(message) = self.receiever.recv().await else {
-            return Err(Error::WebSocketClosed);
+            return Err(Error::WebsocketClosed);
         };
         match message {
             Message::Text(text) => {
@@ -113,7 +113,7 @@ impl<RxMessage: for<'a> Deserialize<'a> + Debug, TxMessage: Serialize + Debug>
                 response_tx: tx,
             })
             .await
-            .map_err(|_| Error::WebSocketClosed)?;
+            .map_err(|_| Error::WebsocketClosed)?;
         // We'll ensure that we always respond before dropping the tx channel
         rx.await.unwrap()
     }
@@ -129,7 +129,7 @@ impl<RxMessage: for<'a> Deserialize<'a> + Debug, TxMessage: Serialize + Debug>
                 response_tx: tx,
             })
             .await
-            .map_err(|_| Error::WebSocketClosed)?;
+            .map_err(|_| Error::WebsocketClosed)?;
         rx.await.unwrap()?;
         self.tx_handle.await.unwrap();
         self.rx_handle.await.unwrap();
@@ -305,7 +305,7 @@ mod tests {
         let close_request = EchoControlMessage::Close;
         socketeer.send(close_request.clone()).await.unwrap();
         let response = socketeer.next_message().await;
-        assert!(matches!(response.unwrap_err(), Error::WebSocketClosed));
+        assert!(matches!(response.unwrap_err(), Error::WebsocketClosed));
         // TODO: Send needs to pass a one-shot and actually wait for the result
         let send_result = socketeer.send(close_request).await;
         assert!(send_result.is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,10 @@ impl<RxMessage: for<'a> Deserialize<'a> + Debug, TxMessage: Serialize + Debug>
         let (socket, response) = connect_async(url.as_str()).await?;
         #[cfg(feature = "tracing")]
         info!("Connection Successful, connection info: \n{:#?}", response);
-        //let (sink, stream) = socket.split();
         let (tx_tx, tx_rx) = mpsc::channel::<TxChannelPayload>(8);
         let (rx_tx, rx_rx) = mpsc::channel::<Message>(8);
 
         let socket_handle = tokio::spawn(async move { socket_loop(tx_rx, rx_tx, socket).await });
-        //let cross_tx = tx_tx.clone();
-        //let rx_handle = tokio::spawn(async move { rx_loop(rx_tx, stream, cross_tx).await });
         Ok(Socketeer {
             _url: url,
             receiever: rx_rx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,10 @@ impl<RxMessage: for<'a> Deserialize<'a> + Debug, TxMessage: Serialize + Debug>
         let (tx, rx) = oneshot::channel::<Result<(), Error>>();
         self.sender
             .send(TxChannelPayload {
-                message: Message::Close(None),
+                message: Message::Close(Some(CloseFrame {
+                    code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                    reason: Utf8Bytes::from_static("Closing Connection"),
+                })),
                 response_tx: tx,
             })
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,16 +224,13 @@ async fn socket_message_received(
             }
             Message::Close(payload) => match state {
                 SocketLoopState::Running => {
-                    let send_result = sink
-                        .send(Message::Close(payload))
-                        .await
-                        .map_err(Error::from);
-                    match send_result {
-                        Ok(()) => SocketLoopState::ShuttingDown,
+                    let close_result = sink.close().await;
+                    match close_result {
+                        Ok(()) => SocketLoopState::Closed,
                         Err(e) => {
                             #[cfg(feature = "tracing")]
                             error!("Error sending Close: {:?}", e);
-                            SocketLoopState::Error(e)
+                            SocketLoopState::Error(Error::from(e))
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,8 @@ async fn send_ping(sink: &mut SocketSink) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use tokio::time::sleep;
-
     use super::*;
+    use tokio::time::sleep;
 
     #[tokio::test]
     async fn test_server_startup() {

--- a/src/mock_server.rs
+++ b/src/mock_server.rs
@@ -62,7 +62,7 @@ pub async fn echo_server(ws: WebSocketStreamType) -> Result<(), tungstenite::Err
                 #[cfg(feature = "tracing")]
                 debug!("Received Pong");
             }
-            Ok(Message::Close(payload)) => {
+            Ok(Message::Close(_)) => {
                 if !shutting_down {
                     sink.close().await.unwrap();
                     drop(stream);


### PR DESCRIPTION
Depends On: #6

Originally the connect function split the socket and spawned two tasks, but this made coordinating them considerably harder.
Unify the tasks into a single loop using `select!` to run the various concerns in parallel, and simplify cross-task coordination.

Closes: #5  